### PR TITLE
Fix activity filtering bug in ActivitiesAdapter

### DIFF
--- a/app/src/main/java/com/example/expenselogger/ActivitiesAdapter.kt
+++ b/app/src/main/java/com/example/expenselogger/ActivitiesAdapter.kt
@@ -13,10 +13,15 @@ import com.example.expenselogger.R
 import com.example.expenselogger.models.ActivityItem
 
 class ActivitiesAdapter(
-    private var activities: MutableList<ActivityItem>,
+    initialActivities: MutableList<ActivityItem>,
     private val listener: OnActivityClickListener,
     private val activityDeleteListener: OnActivityDeleteListener
 ) : RecyclerView.Adapter<ActivitiesAdapter.ActivityViewHolder>() {
+
+    // Maintain an internal copy of the activities list so that external
+    // modifications (like search filters) don't accidentally clear the
+    // master list held by the activity.
+    private val activities: MutableList<ActivityItem> = initialActivities.toMutableList()
 
     interface OnActivityClickListener {
         fun onActivitySelected(activity: ActivityItem)

--- a/app/src/main/java/com/example/expenselogger/MainActivity.kt
+++ b/app/src/main/java/com/example/expenselogger/MainActivity.kt
@@ -354,7 +354,8 @@ class MainActivity : AppCompatActivity(),
         val newId = (activitiesList.maxByOrNull { it.id }?.id ?: DEFAULT_ACTIVITY_ID) + 1
         val newActivity = ActivityItem(newId, name)
         activitiesList.add(newActivity)
-        activitiesAdapter.notifyItemInserted(activitiesList.size - 1)
+        // Update adapter with the new activity so its internal list stays in sync
+        activitiesAdapter.addActivity(newActivity)
     }
 
     private fun loadReceipts() {
@@ -444,9 +445,9 @@ class MainActivity : AppCompatActivity(),
             return
         }
 
-        // Remove the activity from the list
+        // Remove the activity from the master list and update the adapter
         activitiesList.remove(activity)
-        activitiesAdapter.notifyDataSetChanged()
+        activitiesAdapter.removeActivity(activity)
 
         // Reassign receipts to default activity
         receipts.filter { it.activityId == activity.id }

--- a/app/src/test/java/com/example/expenselogger/ActivitiesAdapterTest.kt
+++ b/app/src/test/java/com/example/expenselogger/ActivitiesAdapterTest.kt
@@ -1,0 +1,31 @@
+package com.example.expenselogger
+
+import com.example.expenselogger.models.ActivityItem
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ActivitiesAdapterTest {
+
+    private val clickListener = object : ActivitiesAdapter.OnActivityClickListener {
+        override fun onActivitySelected(activity: ActivityItem) {}
+    }
+
+    private val deleteListener = object : ActivitiesAdapter.OnActivityDeleteListener {
+        override fun onActivityDelete(activity: ActivityItem) {}
+    }
+
+    @Test
+    fun updateActivities_doesNotMutateSourceList() {
+        val original = mutableListOf(
+            ActivityItem(1, "Work"),
+            ActivityItem(2, "Personal")
+        )
+        val adapter = ActivitiesAdapter(original, clickListener, deleteListener)
+
+        // Filter down to a single activity and update the adapter
+        adapter.updateActivities(listOf(original[0]))
+
+        // Original list should remain unchanged
+        assertEquals(2, original.size)
+    }
+}


### PR DESCRIPTION
## Summary
- prevent ActivitiesAdapter from mutating the source activities list
- keep adapter list in sync when adding or removing activities
- add regression test ensuring source list remains unchanged after filtering

## Testing
- `./gradlew test` *(fails: SDK location not found)*
